### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ WORKDIR /usr/share/nginx
 RUN curl -o grav-admin.zip -SL https://getgrav.org/download/core/grav-admin/${GRAV_VERSION} && \
     unzip grav-admin.zip && \
     mv -T /usr/share/nginx/grav-admin /usr/share/nginx/html && \
-    rm grav-admin.zip
+    rm grav-admin.zip && \
+    rm /usr/share/nginx/html/index.html
 
 # Create cron job for Grav maintenance scripts
 # https://learn.getgrav.org/17/advanced/scheduler


### PR DESCRIPTION
Details:

I am running Docker Grav via Nginx proxy-pass, using Podman (rootless Docker).

This PR fixes an issue where navigating to the homepage of a domain results in the index.html (stock nginx splash screen) being displayed, instead of your Grav homepage. However, any pages accessed within subdirectories are _not_ affected.

This bug appears randomly within a few hours. After launching the grav docker container, everything will run just fine, until suddenly, the home page will not be reached; instead, the stock nginx splash screen will get displayed. Screenshots of this are attached at the bottom.

Actions taken to resolve this bug:

[ x ] Removed `index.html` from default nginx install directory. As the `index.php` contains Grav php logic that handles the site, we do not require the default nginx index.

Type: 
[ x ] Bug fix

---

In this screenshot, I've taken the following actions:
* navigated to my prod site which is running this image's container
* I left the `index.html` (default) alone
* `tail -f` the output of the nginx log while I access my site (redacted my IP)
* notice the following: the stock `index.html` page is opened

![broken](https://user-images.githubusercontent.com/36095297/137598025-1d1a7819-c98c-4e95-b1de-2e1045b736d3.png)

In this screenshot, I've taken the following actions:
* navigated to my prod site which is running this image's container
* I renamed the `index.html` file to `.disabled_index.html` (I actually removed it afterwards)
* `tail -f` the output of the nginx log while I access my site (redacted my IP)
* notice the following: my Grav home page is opened

![fixed](https://user-images.githubusercontent.com/36095297/137598082-021214ed-a0bb-450c-bbf2-02fd6513ea8b.png)
