### PR TITLE
fix nginx image update that broke current version of gushmazuko nginx…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,7 @@ WORKDIR /usr/share/nginx
 RUN curl -o grav-admin.zip -SL https://getgrav.org/download/core/grav-admin/${GRAV_VERSION} && \
     unzip grav-admin.zip && \
     mv -T /usr/share/nginx/grav-admin /usr/share/nginx/html && \
-    rm grav-admin.zip && \
-    rm /usr/share/nginx/html/index.html
+    rm grav-admin.zip
 
 # Create cron job for Grav maintenance scripts
 # https://learn.getgrav.org/17/advanced/scheduler
@@ -50,13 +49,14 @@ RUN usermod -aG www-data nginx
 
 # Replace dafault config files by provided by Grav
 # https://learn.getgrav.org/17/webservers-hosting/vps/digitalocean#configure-nginx-connection-pool
-RUN rm /etc/php/7.3/fpm/pool.d/www.conf
+RUN rm /etc/php/7.4/fpm/pool.d/www.conf
 RUN rm /etc/nginx/conf.d/default.conf
-COPY conf/php/grav.conf /etc/php/7.3/fpm/pool.d/
+COPY conf/php/grav.conf /etc/php/7.4/fpm/pool.d/
 COPY conf/nginx/grav.conf /etc/nginx/conf.d/
+COPY conf/nginx/nginx.conf /etc/nginx/
 
 # Provide container inside image for data persistence
 VOLUME ["/usr/share/nginx/html"]
 
 # Run startup script
-CMD bash -c "service php7.3-fpm start && nginx -g 'daemon off;'"
+CMD bash -c "service php7.4-fpm start && nginx -g 'daemon off;'"

--- a/conf/nginx/grav.conf
+++ b/conf/nginx/grav.conf
@@ -30,7 +30,7 @@ server {
     ## Begin - PHP
     location ~ \.php$ {
         # Choose either a socket or TCP/IP address
-        fastcgi_pass unix:/var/run/php/php7.3-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
         # fastcgi_pass unix:/var/run/php5-fpm.sock; #legacy
         # fastcgi_pass 127.0.0.1:9000;
 

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -1,0 +1,32 @@
+user  www-data;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}
+

--- a/conf/php/grav.conf
+++ b/conf/php/grav.conf
@@ -3,7 +3,7 @@
 user = www-data
 group = www-data
 
-listen = /var/run/php/php7.3-fpm.sock
+listen = /var/run/php/php7.4-fpm.sock
 
 listen.owner = www-data
 listen.group = www-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - grav:/usr/share/nginx/html
 #      - ./conf/nginx/:/etc/nginx/conf.d/
-#      - ./conf/php/:/etc/php/7.3/fpm/pool.d/
+#      - ./conf/php/:/etc/php/7.4/fpm/pool.d/
     labels:
       - "traefik.enable=true"
       # http


### PR DESCRIPTION
Hi Gushmazuko.

:bug: I've found a few bugs and failure to install, for the latest version.

1. `rm: cannot remove '/usr/share/nginx/html/index.html': No such file or directory`
2. `connect() to unix:/var/run/php7.3-fpm.sock failed (13: Permission denied) while connecting to upstream`
3. Nginx error 502 after fixing the previous two problems (caused by php-fpm update to version 7.4)

When I tried to build the latest image,  it failed with a few different errors. 
I believe these are due to the latest updates in the base image.

:heavy_check_mark: Bugs fixed

* removed nonexistant index.html from dockerfile
* updated the dockerfile to make use of the latest php7.4-fpm package
* added a small change to the `/etc/nginx/nginx.conf` file; changed the user to www-data

---

:tada: Post install:

The latest image increased by a few MBs due to the latest code and software. Not bad.

```
[fedora@desktop grav-nginx]$ podman images | grep -i grav
localhost/grav-nginx      latest      a6d6ea360653  9 minutes ago  354 MB
[fedora@desktop grav-nginx]$ podman run -p 1234:80 --name grav-nginx -itd localhost/grav-nginx:latest
fe9e9616e0c8370b2b75f67bc8b9e59b0c0fa59004811ffef10c25caf978fa10
[fedora@desktop grav-nginx]$ curl -I localhost:1234
HTTP/1.1 302 Found
Server: nginx/1.21.6
Date: Wed, 26 Jan 2022 19:27:37 GMT
Content-Type: text/html; charset=UTF-8
Connection: keep-alive
Set-Cookie: grav-site-cf45e6e=t8tg5a2mgot7e8v6ae6dfg0aoa; expires=Wed, 26-Jan-2022 19:57:37 GMT; Max-Age=1800; path=/; HttpOnly; SameSite=Lax
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate
Pragma: no-cache
Location: /admin
```
Screenshot:
![image](https://user-images.githubusercontent.com/36095297/151233145-0c6cc8bc-10ef-46d3-8bc6-b30a1824e6b9.png)
